### PR TITLE
threshold_rewrite

### DIFF
--- a/.github/workflows/contracts-docs.yaml
+++ b/.github/workflows/contracts-docs.yaml
@@ -47,10 +47,10 @@ jobs:
 
   # This job will be triggered for releases which name starts with
   # `refs/tags/v`. It will generate contracts documentation in
-  # Markdown and sync it with a specific path of
-  # `threshold-network/threshold` repository. If changes will be detected,
-  # a PR updating the docs will be created in the destination repository. The
-  # commit pushing the changes will be verified using GPG key.
+  # Markdown and sync it with a specific path of the `threshold-network/docs`
+  # repository. If changes will be detected, a PR updating the docs will be
+  # created in the destination repository. The commit pushing the changes will
+  # be verified using GPG key.
   contracts-docs-publish:
     name: Publish contracts documentation
     needs: docs-detect-changes
@@ -59,7 +59,7 @@ jobs:
     with:
       publish: true
       verifyCommits: true
-      destinationRepo: threshold-network/threshold
+      destinationRepo: threshold-network/docs
       destinationFolder: ./docs/app-development/staking-contract-and-dao/staking-contract-and-dao-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com


### PR DESCRIPTION
We're renaming some of the repositories in the `threshold-network` organization. One of them is `threshold` repo, which will be renamed to `docs`. We need to update the references of the old name.